### PR TITLE
Allow 2222/tcp in UFW

### DIFF
--- a/external/sketch/provision.sh
+++ b/external/sketch/provision.sh
@@ -54,6 +54,7 @@ chmod 440 /etc/sudoers.d/99user
 ufw allow ssh
 ufw allow http
 ufw allow https
+ufw allow 2222/tcp
 ufw --force enable
 apt-get -y install unattended-upgrades
 


### PR DESCRIPTION
Fixes RTI-158
2222/tcp is opened in UFW when `provision.sh` is run.