### PR TITLE
Web-check role

### DIFF
--- a/ansible/roles/web-check/README.md
+++ b/ansible/roles/web-check/README.md
@@ -1,0 +1,27 @@
+web-check
+=========
+
+> Get an insight into the inner-workings of a given website: uncover potential attack vectors, analyse server architecture, view security configurations, and learn what technologies a site is using.
+
+The web-check project can be found via [https://github.com/lissy93/web-check](https://github.com/lissy93/web-check)
+
+Advised to run this on a proxy in the event you want to perform analyzation of your website or DNS record for any potential OPSEC leaks.
+
+Requirements
+------------
+
+Docker needs to be installed on the target host. The docker role included in redteam-infra is included to ensure docker is installed.
+
+Dependencies
+------------
+
+`docker` role
+
+Example Playbook
+----------------
+
+```yml
+- hosts: servers
+  roles:
+   - web-check
+```

--- a/ansible/roles/web-check/files/docker-compose.yml
+++ b/ansible/roles/web-check/files/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  web-check:
+    image: lissy93/web-check
+    restart: unless-stopped
+    ports:
+      - "3000:3000"

--- a/ansible/roles/web-check/meta/main.yml
+++ b/ansible/roles/web-check/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/ansible/roles/web-check/tasks/main.yml
+++ b/ansible/roles/web-check/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# tasks file for web-check
+- name: Include docker role
+  include_role:
+    name: docker
+
+- name: Create user webchecker
+  user:
+    name: webchecker
+    home: /opt/web-check
+    system: true
+    shell: /usr/sbin/nologin
+    state: present
+
+- name: Copy docker-compose.yml
+  copy:
+    src: files/docker-compose.yml
+    dest: /opt/webchecker/docker-compose.yml
+    owner: webchecker
+    group: webchecker
+    mode: 0600
+
+- name: Run docker-compose web-check
+  command: docker compose up -d
+  args:
+    chdir: /opt/web-check

--- a/ansible/roles/web-check/tests/inventory
+++ b/ansible/roles/web-check/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible/roles/web-check/tests/test.yml
+++ b/ansible/roles/web-check/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - web-check


### PR DESCRIPTION
I am the author of this change and approve of it being added to the project per the `contributing.md`

This adds the role for web-check which is a tool developed by lissy93 here on GitHub. 

Best used on a proxy to check for any OPSEC leaks on Websites, DNS records, SSL Certs, etc