### PR TITLE
Update AWS to use per-engagement generated key

### DIFF
--- a/external/aws/README.md
+++ b/external/aws/README.md
@@ -33,9 +33,6 @@ shared_credentials_file = "~/.aws/credentials"
 #ssh_config_path              = ""
 profile = "redteam-infra"
 
-#Key Pair for sshing to hosts
-key_name = "~/.ssh/id_rsa"
-public_key = "~/.ssh/id_rsa.pub"
 
 # Which region
 aws_key_name = ""

--- a/external/aws/README.md
+++ b/external/aws/README.md
@@ -25,36 +25,32 @@ You will also need to set up a `variables.tfvars` file see the `example-variable
 
 ``` terraform
 # Provider initialization (tenancy, api user, key, region, etc.)
-shared_credentials_file = "~/.aws/credentials"
 
-
-
-# Optional, default path is `~/.ssh`
-#ssh_config_path              = ""
 profile = "redteam-infra"
 
+# Optional, default path is `~/.ssh`
+ssh_config_path = "~/.ssh/redteam-ssh-configs/configs"
 
-# Which region
-aws_key_name = ""
-# use the Region Identifier, e.g: us-west-2
-region         = "us-west-2"
+# Use the region identifier, e.g: us-west-2
+region            = "us-west-2"
 # Which availability zone
-availability_zone      = "us-west-2a"
+availability_zone = "us-west-2a"
 
 # The engagement's name, infrastructure will be named after this
-engagement_name = "test"
+engagement_name = ""
 
-#"dev" = "t3.medium"
-#"prod" = "t3.large"
-# define the shape for homebase
+# A good development shape is "t3.medium", a good production shape is "t3.large"
+# Define the shape for homebase
 homebase_shape = "t3.medium"
-# define the shape for proxies
+
+# Define the shape for proxies
 proxy_shape    = "t3.medium"
 proxy_count    = 2
-# define the shape for elk
+
+# Define the shape for elk
 elk_shape      = "t3.medium"
 
-# Set to IP's and/or IP ranges you would like to have SSH access to the infrastructure
+# Set to IP addresses and/or IP ranges you would like to have SSH access to the infrastructure
 # Each item in range should be an address range in cidr formate
 # e.g. ssh_allowed_cidr_ranges = ["192.168.32.0/25", "172.16.0.0/16"]
 ssh_allowed_cidr_ranges = [""]

--- a/external/aws/aws_keypair.tf
+++ b/external/aws/aws_keypair.tf
@@ -1,4 +1,4 @@
 resource "aws_key_pair" "deployer" {
-  key_name   = var.key_name
-  public_key = file(var.public_key)
+  key_name   = "deployer"
+  public_key = tls_private_key.ssh_key.public_key_openssh
 }

--- a/external/aws/elk.tf
+++ b/external/aws/elk.tf
@@ -4,18 +4,18 @@ resource "aws_instance" "elk" {
   instance_type = var.elk_shape
   key_name = aws_key_pair.deployer.key_name
 
-  subnet_id = "${aws_subnet.infra.id}"
+  subnet_id = aws_subnet.infra.id
   private_ip = "192.168.1.13"
   associate_public_ip_address = true
   vpc_security_group_ids = [
-    "${aws_security_group.internal.id}",
+    aws_security_group.internal.id,
   ]
     root_block_device {
     volume_type = "standard"
     volume_size = var.boot_volume_size_in_gbs
   }
   tags = {
-    Op = "${var.engagement_name}"
+    Op = var.engagement_name
     Name = "elk-${var.engagement_name}"
   }
 

--- a/external/aws/elk.tf
+++ b/external/aws/elk.tf
@@ -2,7 +2,7 @@ resource "aws_instance" "elk" {
   depends_on = [ aws_instance.homebase ]
   ami = data.aws_ami.ubuntu.id
   instance_type = var.elk_shape
-  key_name = var.key_name
+  key_name = aws_key_pair.deployer.key_name
 
   subnet_id = "${aws_subnet.infra.id}"
   private_ip = "192.168.1.13"

--- a/external/aws/generate-keypair.tf
+++ b/external/aws/generate-keypair.tf
@@ -1,0 +1,3 @@
+resource "tls_private_key" "ssh_key" {
+  algorithm = "ED25519"
+}

--- a/external/aws/homebase.tf
+++ b/external/aws/homebase.tf
@@ -14,7 +14,7 @@ resource "aws_instance" "homebase" {
     volume_size = var.boot_volume_size_in_gbs
   }
   tags = {
-    Op = "${var.engagement_name}"
+    Op = var.engagement_name
     Name = format("homebase-%s", var.engagement_name)
   }
 }

--- a/external/aws/homebase.tf
+++ b/external/aws/homebase.tf
@@ -1,7 +1,7 @@
 resource "aws_instance" "homebase" {
   ami = data.aws_ami.ubuntu.id
   instance_type = var.homebase_shape
-  key_name = var.key_name
+  key_name = aws_key_pair.deployer.key_name
   subnet_id = aws_subnet.infra.id
   private_ip = "192.168.0.10"
   associate_public_ip_address = true
@@ -17,5 +17,4 @@ resource "aws_instance" "homebase" {
     Op = "${var.engagement_name}"
     Name = format("homebase-%s", var.engagement_name)
   }
-
 }

--- a/external/aws/network.tf
+++ b/external/aws/network.tf
@@ -117,7 +117,7 @@ resource "aws_security_group" "internal" {
   }
 
   tags = {
-    Op = "${var.engagement_name}"
+    Op = var.engagement_name
     Name = "${var.engagement_name}_internal"
   }
 }
@@ -147,7 +147,7 @@ resource "aws_security_group" "web_from_all" {
 resource "aws_security_group" "dns_from_all" {
   name = format("%s_dns_from_all", var.engagement_name)
   description = "Allow incoming dns connections"
-  vpc_id = "${aws_vpc.infra_vpc.id}"
+  vpc_id = aws_vpc.infra_vpc.id
   ingress  {
     from_port = 53
     to_port = 53
@@ -161,7 +161,7 @@ resource "aws_security_group" "dns_from_all" {
     cidr_blocks = ["0.0.0.0/0"]
   }
   tags = {
-    Op = "${var.engagement_name}"
+    Op = var.engagement_name
     Name = "${var.engagement_name}_dns_from_all"
   }
 }

--- a/external/aws/provider.tf
+++ b/external/aws/provider.tf
@@ -8,6 +8,7 @@ terraform {
 
 provider "aws" {
   profile = var.profile
+  region = var.region
 }
 
 provider "local" {}

--- a/external/aws/proxies.tf
+++ b/external/aws/proxies.tf
@@ -8,8 +8,8 @@ resource "aws_instance" "proxy" {
     volume_type = "standard"
     volume_size = var.boot_volume_size_in_gbs
   }
-  subnet_id = "${aws_subnet.infra.id}"
-  private_ip = "${format("192.168.2.%d", count.index + 11)}"
+  subnet_id = aws_subnet.infra.id
+  private_ip = format("192.168.2.%d", count.index + 11)
   associate_public_ip_address = true
   vpc_security_group_ids = [
     aws_security_group.internal.id,

--- a/external/aws/proxies.tf
+++ b/external/aws/proxies.tf
@@ -3,7 +3,7 @@ resource "aws_instance" "proxy" {
   count = var.proxy_count
   ami = data.aws_ami.ubuntu.id
   instance_type = var.proxy_shape
-  key_name = var.key_name
+  key_name = aws_key_pair.deployer.key_name
   root_block_device {
     volume_type = "standard"
     volume_size = var.boot_volume_size_in_gbs

--- a/external/aws/variables.tf
+++ b/external/aws/variables.tf
@@ -31,15 +31,6 @@ variable "shared_credentials_file" {
   default = "~/.aws/credentials"
 }
 
-variable "key_name" {
-  default = "~/.ssh/id_rsa"
-}
-
-variable "public_key" {
-  default = "~/.ssh/id_rsa.pub"
-  
-}
-
 variable "engagement_name" {
 }
 

--- a/external/aws/variables.tf
+++ b/external/aws/variables.tf
@@ -27,10 +27,6 @@ variable "availability_zone" {
   default = "us-west-2a"
 }
 
-variable "shared_credentials_file" {
-  default = "~/.aws/credentials"
-}
-
 variable "engagement_name" {
 }
 

--- a/external/aws/variables.tfvars.example
+++ b/external/aws/variables.tfvars.example
@@ -1,32 +1,30 @@
 # Provider initialization (tenancy, api user, key, region, etc.)
 
-# Shared Crediental file Path
-shared_credentials_file = "~/.aws/credentials"
 profile = "redteam-infra"
-
 
 # Optional, default path is `~/.ssh`
 ssh_config_path = "~/.ssh/redteam-ssh-configs/configs"
 
-# use the Region Identifier, e.g: us-west-2
-region = ""
+# Use the region identifier, e.g: us-west-2
+region            = "us-west-2"
 # Which availability zone
-availability_zone = ""
+availability_zone = "us-west-2a"
 
 # The engagement's name, infrastructure will be named after this
 engagement_name = ""
 
-#"dev" = "t3.medium"
-#"prod" = "t3.large"
-# define the shape for homebase
+# A good development shape is "t3.medium", a good production shape is "t3.large"
+# Define the shape for homebase
 homebase_shape = "t3.medium"
-# define the shape for proxies
+
+# Define the shape for proxies
 proxy_shape    = "t3.medium"
 proxy_count    = 2
-# define the shape for elk
+
+# Define the shape for elk
 elk_shape      = "t3.medium"
 
-# Set to IP's and/or IP ranges you would like to have SSH access to the infrastructure
+# Set to IP addresses and/or IP ranges you would like to have SSH access to the infrastructure
 # Each item in range should be an address range in cidr formate
 # e.g. ssh_allowed_cidr_ranges = ["192.168.32.0/25", "172.16.0.0/16"]
 ssh_allowed_cidr_ranges = [""]

--- a/external/aws/variables.tfvars.example
+++ b/external/aws/variables.tfvars.example
@@ -6,12 +6,7 @@ profile = "redteam-infra"
 
 
 # Optional, default path is `~/.ssh`
-#ssh_config_path              = ""
-
-#Key Pair for sshing to hosts
-key_name = "~/.ssh/id_rsa"
-public_key = "~/.ssh/id_rsa.pub"
-
+ssh_config_path = "~/.ssh/redteam-ssh-configs/configs"
 
 # use the Region Identifier, e.g: us-west-2
 region = ""


### PR DESCRIPTION
Make the AWS terraform to be more in-line with the OCI. AWS will now generate a per-engagement ssh key instead of having to specify one.