### PR TITLE
AWS key-pairs need to be unique

### DIFF
--- a/external/aws/aws_keypair.tf
+++ b/external/aws/aws_keypair.tf
@@ -1,4 +1,4 @@
 resource "aws_key_pair" "deployer" {
-  key_name   = "deployer"
+  key_name   = "deployer-${var.engagement_name}"
   public_key = tls_private_key.ssh_key.public_key_openssh
 }


### PR DESCRIPTION
Add engagement name to the key-pair to ensure that it is unique, but still human readable.