### PR TITLE
Optional default tagging for all resources

### DIFF
--- a/external/aws/provider.tf
+++ b/external/aws/provider.tf
@@ -8,7 +8,10 @@ terraform {
 
 provider "aws" {
   profile = var.profile
-  region = var.region
+  region  = var.region
+  default_tags {
+    tags = var.default_tags
+  } 
 }
 
 provider "local" {}

--- a/external/aws/variables.tf
+++ b/external/aws/variables.tf
@@ -37,3 +37,8 @@ variable "vpc_cidr_block" {
 variable "ssh_allowed_cidr_ranges" {
   type = set(string)
 }
+
+variable "default_tags" {
+  type = map(string)
+  default = {}
+}

--- a/external/aws/variables.tfvars.example
+++ b/external/aws/variables.tfvars.example
@@ -28,3 +28,7 @@ elk_shape      = "t3.medium"
 # Each item in range should be an address range in cidr formate
 # e.g. ssh_allowed_cidr_ranges = ["192.168.32.0/25", "172.16.0.0/16"]
 ssh_allowed_cidr_ranges = [""]
+
+
+# Default tags to add (in addition to individual tags) to all resources
+default_tags   = {"example-name":"example-value"}


### PR DESCRIPTION
Adds a variable to specify additional tags to apply to all provisioned resources that support tagging.  Default is left to no additional tags.