### PR TITLE
Lifecycle Management for AMI and formatting

### DIFF
--- a/external/aws/elk.tf
+++ b/external/aws/elk.tf
@@ -1,22 +1,29 @@
 resource "aws_instance" "elk" {
-  depends_on = [ aws_instance.homebase ]
-  ami = data.aws_ami.ubuntu.id
-  instance_type = var.elk_shape
-  key_name = aws_key_pair.deployer.key_name
-
-  subnet_id = aws_subnet.infra.id
-  private_ip = "192.168.1.13"
+  depends_on                  = [ aws_instance.homebase ]
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.elk_shape
+  key_name                    = aws_key_pair.deployer.key_name
+  subnet_id                   = aws_subnet.infra.id
+  private_ip                  = "192.168.1.13"
   associate_public_ip_address = true
+
   vpc_security_group_ids = [
     aws_security_group.internal.id,
   ]
-    root_block_device {
+
+  root_block_device {
     volume_type = "standard"
     volume_size = var.boot_volume_size_in_gbs
   }
+
   tags = {
-    Op = var.engagement_name
+    Op   = var.engagement_name
     Name = "elk-${var.engagement_name}"
   }
 
+  lifecycle {
+    ignore_changes = [
+      ami,  # Ignore changes to the AMI, you don't want TF to destroy resources if it is updated
+    ]
+  }
 }

--- a/external/aws/homebase.tf
+++ b/external/aws/homebase.tf
@@ -1,20 +1,33 @@
 resource "aws_instance" "homebase" {
-  ami = data.aws_ami.ubuntu.id
-  instance_type = var.homebase_shape
-  key_name = aws_key_pair.deployer.key_name
-  subnet_id = aws_subnet.infra.id
-  private_ip = "192.168.0.10"
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.homebase_shape
+  key_name                    = aws_key_pair.deployer.key_name
+  subnet_id                   = aws_subnet.infra.id
+  private_ip                  = "192.168.0.10"
   associate_public_ip_address = true
+
   vpc_security_group_ids = [
     aws_security_group.ssh_from_company.id,
     aws_security_group.internal.id,
   ]
-   root_block_device {
+
+  metadata_options {
+    http_tokens = "required" # enable imds v2
+  }
+
+  root_block_device {
     volume_type = "standard"
     volume_size = var.boot_volume_size_in_gbs
   }
+
   tags = {
-    Op = var.engagement_name
+    Op   = var.engagement_name
     Name = format("homebase-%s", var.engagement_name)
+  }
+
+  lifecycle {
+    ignore_changes = [
+      ami,  # Ignore changes to the AMI, you don't want TF to destroy resources if it is updated
+    ]
   }
 }

--- a/external/aws/proxies.tf
+++ b/external/aws/proxies.tf
@@ -1,24 +1,35 @@
 resource "aws_instance" "proxy" {
-  depends_on = [ aws_instance.homebase ]
-  count = var.proxy_count
-  ami = data.aws_ami.ubuntu.id
-  instance_type = var.proxy_shape
-  key_name = aws_key_pair.deployer.key_name
+  depends_on                  = [ aws_instance.homebase ]
+  count                       = var.proxy_count
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.proxy_shape
+  key_name                    = aws_key_pair.deployer.key_name
+  subnet_id                   = aws_subnet.infra.id
+  private_ip                  = format("192.168.2.%d", count.index + 11)
+  associate_public_ip_address = true
+
   root_block_device {
     volume_type = "standard"
     volume_size = var.boot_volume_size_in_gbs
   }
-  subnet_id = aws_subnet.infra.id
-  private_ip = format("192.168.2.%d", count.index + 11)
-  associate_public_ip_address = true
+
   vpc_security_group_ids = [
     aws_security_group.internal.id,
     aws_security_group.web_from_all.id
   ]
-  
+
+  metadata_options {
+    http_tokens = "required" # enable imds v2
+  }
+
   tags = {
-    Op = var.engagement_name
+    Op   = var.engagement_name
     Name = "proxy${format("%02g", count.index + 1)}-${var.engagement_name}"
   }
 
+  lifecycle {
+    ignore_changes = [
+      ami,  # Ignore changes to the AMI, you don't want TF to destroy resources if it is updated
+    ]
+  }
 }

--- a/external/aws/variables.tfvars.example
+++ b/external/aws/variables.tfvars.example
@@ -29,6 +29,5 @@ elk_shape      = "t3.medium"
 # e.g. ssh_allowed_cidr_ranges = ["192.168.32.0/25", "172.16.0.0/16"]
 ssh_allowed_cidr_ranges = [""]
 
-
 # Default tags to add (in addition to individual tags) to all resources
-default_tags   = {"example-name":"example-value"}
+#default_tags   = { "example-name": "example-value" }


### PR DESCRIPTION
Enable lifecycle management on EC2 ami. Ensure that EC2 isn't recreated if ami is changed.

Minor reformatting of files touched, including making it easier for default_tags to be read