### PR TITLE
fix GOPROXY problems

### DIFF
--- a/ansible/roles/mythic/README.md
+++ b/ansible/roles/mythic/README.md
@@ -25,7 +25,7 @@ Be sure to replace `<AGENT>` with the agent you would like to install.
 No C2 profiles are installed by default. You can install C2 profiles by visiting https://github.com/MythicC2Profiles and then use:
 
 ```commandline
-cd /opt/mythic && sudo ./mythic-cli install https://github.com/MythicC2Profiles/<PROFILE>
+cd /opt/mythic && sudo ./mythic-cli install github https://github.com/MythicC2Profiles/<PROFILE>
 ```
 
 Be sure to replace `<PROFILE>` with the profile you would like to install.

--- a/ansible/roles/mythic/tasks/install_mythic.yml
+++ b/ansible/roles/mythic/tasks/install_mythic.yml
@@ -24,6 +24,8 @@
 
 - name: Run Mythic installer
   command: /tmp/install_mythic.sh
+  environment:
+    GOPROXY: "https://proxy.golang.org"
 
 - name: Cleanup Mythic installer
   file:

--- a/ansible/roles/mythic/tasks/start_mythic.yml
+++ b/ansible/roles/mythic/tasks/start_mythic.yml
@@ -7,6 +7,8 @@
 
 - name: Run Mythic starter
   command: /tmp/start_mythic.sh
+  environment:
+    GOPROXY: "https://proxy.golang.org"
 
 - name: Cleanup Mythic starter
   file:


### PR DESCRIPTION
- Building mythic was failing when GOPROXY was set to an empty string. Setting the GOPROXY environment variable to golang.org's proxy fixes the issue
- Update the README to fix mythic cli install command