### PR TITLE
Ingress restrictions

### DIFF
--- a/external/sketch/ansible/roles/ingress-restrictions/README.md
+++ b/external/sketch/ansible/roles/ingress-restrictions/README.md
@@ -1,0 +1,24 @@
+ingress-restrictions
+=========
+
+This role is used to help reduce the chances for backflip correlation from public ssh keys from tools like Censys.
+
+This will automatically tell middle hosts to only allow connections on port 2222 from edge hosts.
+
+This role only handles the sketch infrastructure as of now.
+
+Requirements
+------------
+
+Once you've ran this in your Sketch infrastructure, you will need to grab the IP Addresses or IP Address range from your middles and add them to your OCI/AWS infrastructure manually.
+
+Whenever we do the grand restructure, this should be done automatically for you everywhere.
+
+Example Playbook
+----------------
+
+```yml
+- hosts: all
+  roles:
+    - ingress-restrictions
+```

--- a/external/sketch/ansible/roles/ingress-restrictions/defaults/main.yml
+++ b/external/sketch/ansible/roles/ingress-restrictions/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Default backflip port for ingress restrictions
+backflip_port: "2222"

--- a/external/sketch/ansible/roles/ingress-restrictions/meta/main.yml
+++ b/external/sketch/ansible/roles/ingress-restrictions/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/external/sketch/ansible/roles/ingress-restrictions/tasks/main.yml
+++ b/external/sketch/ansible/roles/ingress-restrictions/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# tasks file for ingress-restrictions
+
+- name: Set fact for 'edge' hosts
+  set_fact:
+    is_edge_host: true
+  when: "'edge' in inventory_hostname"
+
+- name: Gather Edge IPs into a dictionary
+  set_fact:
+    edge_ips_dict: >-
+      {{
+        edge_ips_dict | default({}) | combine(
+          { item: hostvars[item]['host_ip_address'] }
+        )
+      }}
+  loop: "{{ groups['all'] }}"
+  when: hostvars[item]['is_edge_host'] is defined and hostvars[item]['is_edge_host']
+  delegate_to: localhost
+
+- name: Allow port 2222 from Edges to Middles
+  ufw:
+    rule: allow
+    port: 2222
+    from_ip: "{{ item.value }}"
+  with_items: "{{ edge_ips_dict | dict2items }}"
+  when: "'middle' in inventory_hostname"
+
+- name: Deny port 2222
+  ufw:
+    rule: deny
+    port: 2222
+  when: "'middle' in inventory_hostname"

--- a/external/sketch/ansible/roles/ingress-restrictions/tasks/main.yml
+++ b/external/sketch/ansible/roles/ingress-restrictions/tasks/main.yml
@@ -18,16 +18,16 @@
   when: hostvars[item]['is_edge_host'] is defined and hostvars[item]['is_edge_host']
   delegate_to: localhost
 
-- name: Allow port 2222 from Edges to Middles
+- name: Allow port {{ backflip_port }} from Edges to Middles
   ufw:
     rule: allow
-    port: 2222
+    port: "{{ backflip_port }}"
     from_ip: "{{ item.value }}"
   with_items: "{{ edge_ips_dict | dict2items }}"
   when: "'middle' in inventory_hostname"
 
-- name: Deny port 2222
+- name: Deny port {{ backflip_port }}
   ufw:
     rule: deny
-    port: 2222
+    port: "{{ backflip_port }}"
   when: "'middle' in inventory_hostname"

--- a/external/sketch/ansible/roles/ingress-restrictions/tests/inventory
+++ b/external/sketch/ansible/roles/ingress-restrictions/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/external/sketch/ansible/roles/ingress-restrictions/tests/test.yml
+++ b/external/sketch/ansible/roles/ingress-restrictions/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ingress-restrictions


### PR DESCRIPTION
Addition of the ingress-restrictions to allow edge hosts to reach middle hosts on port 2222. 

Resolves #70 