### PR TITLE
Metadata query check

### DIFF
--- a/external/sketch/ansible/roles/disable-ipv6/tasks/main.yml
+++ b/external/sketch/ansible/roles/disable-ipv6/tasks/main.yml
@@ -1,11 +1,29 @@
 ---
 # tasks file for disable-ipv6
+
+# Check for provider, especially linode
+- name: Query metadata service
+  uri:
+    url: "http://169.254.169.254/v1/instance"
+    return_content: yes
+    status_code: 400
+  register: system_metadata
+  ignore_errors: yes
+
+- name: Set is_linode based on metadata
+  set_fact:
+    is_linode: "{{ 'errors.reason' in system_metadata.content }}" # Without token added this response appears for Linode. DO uses "not found"
+  when: system_metadata is defined
+
+# Disable ipv6 steps if Linode
+
 - name: Make iptables Dir
   file:
     path: /etc/ip6tables
     state: directory
     owner: root
     mode: 0755
+  when: is_linode
 
 - name: Copy ip6tables Rules
   copy:
@@ -13,21 +31,25 @@
     dest: /etc/ip6tables/rules.v6
     owner: root
     mode: 0755
+  when: is_linode
 
 - name: Stop resovled
   systemd:
     name: systemd-resolved.service
     state: stopped
+  when: is_linode
 
 - name: Disable resovled
   systemd:
     name: systemd-resolved.service
     enabled: false
+  when: is_linode
 
 - name: Mask resolved
   systemd:
     name: systemd-resolved.service
     masked: true
+  when: is_linode
 
 - name: Add dns server
   template:
@@ -35,12 +57,14 @@
     dest: /etc/resolv.conf
     owner: root
     mode: 0755
+  when: is_linode
 
 - name: Modify ipv6 in UFW
   lineinfile:
     path: /etc/default/ufw
     regex: '^IPV6='
     line: 'IPV6=no'
+  when: is_linode
 
 - name: Create Systemd Service to Restore IPv6 Rules
   copy:
@@ -48,9 +72,11 @@
     dest: /etc/systemd/system/restore-ip6tables.service
     owner: root
     mode: 0755
+  when: is_linode
 
 - name: Enable and start restore-ip6tables service
   systemd:
     name: restore-ip6tables
     enabled: yes  
     state: reloaded
+  when: is_linode


### PR DESCRIPTION
## Changelog 

With the expansion of our sketch providers to shortly support Digital Ocean, which utilizes ipv6 differently from Linode, this is used to make sure we don't foobar our Digital Ocean setup.

Digital Ocean requires the usage of systemd-resolved and utilizes hard coded/static `/etc/netplan/*.yaml` setup. 

The current disable-ipv6 role if applied to Digital Ocean will break the ansible flow specifically around when the system tries to update or do anything after that. Digital Ocean is reliant on systemd-resolved for its DNS resolution for internal and external.

Regardless of whether this role is applied in the playbook now, if its a Linode system it will run and if its anything else the role's tasks are skipped.

**Improved**
* Perform a metadata API call to check if on Linode
* If linode, apply the ipv6 changes otherwise skip