### PR TITLE
Feature: Add Digital Ocean Sketch Provider

### DIFF
--- a/external/sketch/README.md
+++ b/external/sketch/README.md
@@ -5,6 +5,7 @@ A very simple set of provision scripts for zero-trust reflector proxies.
 # Moving Parts
 
 If you are using Linode, skip `provision.sh` and use the Linode instructions
+If you are using Digital Ocean, skip `provision.sh` and use the Digital Ocean instructions
 
 ## provision.sh
 
@@ -27,6 +28,9 @@ You will need to add a SSH public key to this script.
 
 ## Linode
 See `linode/README.md`
+
+## Digital Ocean
+See `digitalocean/README.md`
 
 ### How to Play with provision.sh
 

--- a/external/sketch/digitalocean/README.md
+++ b/external/sketch/digitalocean/README.md
@@ -1,0 +1,89 @@
+# How to Play
+
+## How to start
+
+The first thing you'll need to do is set up a Digital Ocean account.
+
+You will need to generate a [Digital Ocean Personal Access Token (PAT)](https://cloud.digitalocean.com/account/api/tokens)
+
+Next, copy `variables.tfvars.example` to  `variables.tfvars` and edit to suit your needs:
+
+``` terraform
+# Your Digital Ocean Personal Accecss Token
+do_pat = ""
+
+# Which Digital Ocean region should these be built in
+middle_region = ""
+edge_regions   = [""]
+
+# Host image you would like to use
+docean_image = ""
+
+# Shortname for the engagement, will be used to identify resources in Digital Ocean and hostnames
+engagement_name = ""
+
+# Path to place your ssh configuration for this infrastructure
+ssh_config_path = ""
+
+# Change me if you are using different keys than those that are generated with homebase instantiation.
+# Give the path to the private
+# ssh_priv_key_path =
+# ssh_pub_key_path =
+```
+
+## Spin up Instances
+
+From there you can run
+
+1. `terraform init`
+2. `terraform apply -var-file=variables.tfvars`
+3. Run the output ansible command to configure your hosts `ansible-playbook ../ansible/sketch-playbook.yml -i inventory.ini -e "ssh_key=KEY" -e "ssh_config_path=PATH"` or use `provision.sh` to configure them manually.
+
+## Advanced configuration
+
+A basic configuration will allow you to setup one `middle` and one `edge` instance in your region of choice. You may use these variables in your `variables.tfvars` to change them:
+
+### ssh keys
+By default the public keys placed on the instances will be `~/.ssh/${engagement_name}.pub`. You can change this by overw ritting the default value of `ssh_key_path` in `variables.tfvars`.
+
+```terraform 
+
+### Regions
+Configure different regions for your middle and edge instances.
+
+```terraform
+middle_region = "REGION-A"
+edge_regions   = ["REGION-B",  "REGION-C", "REGION-D"]
+```
+
+### Instance Count
+Configure multiple edge instances. (Can also be done with middle)
+
+```terraform
+edge_count_per_region = "N"
+```
+
+#### Multiple Regions and Instance Count > 1
+
+If you configure you variables like so:
+
+```terraform
+edge_regions   = ["REGION-B",  "REGION-C", "REGION-D"]
+edge_count_per_region = "2"
+```
+
+You will produce a total of **6** instances:
+
+- `engagement-REGION-B-01` 
+- `engagement-REGION-B-02` 
+- `engagement-REGION-C-01` 
+- `engagement-REGION-C-02` 
+- `engagement-REGION-D-01` 
+- `engagement-REGION-D-02`
+
+### Instance Type
+Can be done with both middle and edge instances.
+
+```terraform
+middle_type = "g6-nanode-1"
+```

--- a/external/sketch/digitalocean/edge.tf
+++ b/external/sketch/digitalocean/edge.tf
@@ -1,0 +1,9 @@
+resource "digitalocean_droplet" "edge" {
+  name           = "edge-${var.engagement_name}-${element(var.edge_regions, floor(count.index / var.edge_count_per_region))}-${format("%02g", (count.index % var.edge_count_per_region) + 1)}"
+  region          = element(var.edge_regions, floor(count.index / var.edge_count_per_region))
+  count           = var.edge_count_per_region * length(var.edge_regions)
+  size            = var.edge_size
+  image           = var.docean_image
+  tags            = [var.engagement_name]
+  ssh_keys = [digitalocean_ssh_key.key.id]
+}

--- a/external/sketch/digitalocean/firewall.tf
+++ b/external/sketch/digitalocean/firewall.tf
@@ -1,0 +1,61 @@
+resource "digitalocean_firewall" "firewall" {
+  name        = "${var.engagement_name}-firewall"
+  droplet_ids = flatten([digitalocean_droplet.middle.*.id, digitalocean_droplet.edge.*.id])
+  tags        = [var.engagement_name]
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "1-65535"
+    source_addresses = ["0.0.0.0/0"]
+  }
+
+  dynamic "inbound_rule" {
+    // Allow all TCP ports specified in the allowed_tcp_ports variable from anywhere
+    for_each = var.allowed_tcp_ports
+    content {
+      protocol         = "tcp"
+      port_range       = inbound_rule.value
+      source_addresses = ["0.0.0.0/0"]
+    }
+  }
+
+  dynamic "inbound_rule" {
+    // Allow engagement hosts to access each other
+    for_each = ["tcp", "udp", "icmp"]
+    content {
+      protocol         = inbound_rule.value
+      port_range       = "1-65535"
+      source_addresses = [for ip in flatten([digitalocean_droplet.middle.*.ipv4_address, digitalocean_droplet.edge.*.ipv4_address]): "${ip}/32"]
+    }
+  }
+
+  dynamic "inbound_rule" {
+    // Block all IPv6 traffic inbound
+    for_each = ["tcp", "udp", "icmp"]
+    content {
+      protocol         = inbound_rule.value
+      port_range       = "1-65535"
+      source_addresses = ["::/0"]
+    }
+  }
+
+  outbound_rule {
+    protocol           = "tcp"
+    port_range         = "1-65535"
+    destination_addresses = ["0.0.0.0/0"]
+  }
+
+  dynamic "outbound_rule" {
+    // Block all IPv6 traffic outbound
+    for_each = ["tcp", "udp", "icmp"]
+    content {
+      protocol              = outbound_rule.value
+      port_range            = "1-65535"
+      destination_addresses = ["::/0"]
+    }
+  }
+
+  outbound_rule {
+    protocol                = "icmp"
+    destination_addresses = ["0.0.0.0/0"]
+  }
+}

--- a/external/sketch/digitalocean/main.tf
+++ b/external/sketch/digitalocean/main.tf
@@ -1,0 +1,7 @@
+locals {
+  abs_ssh_config_path  = pathexpand("${var.ssh_config_path}/${var.engagement_name}-sketch")
+  default_ssh_priv_key = pathexpand("~/.ssh/${var.engagement_name}")
+  default_ssh_pub_key  = pathexpand("~/.ssh/${var.engagement_name}.pub")
+  ssh_priv_key_path    = length(var.ssh_priv_key_path) > 0 ? var.ssh_priv_key_path : local.default_ssh_priv_key
+  ssh_pub_key_path     = length(var.ssh_pub_key_path) > 0 ? var.ssh_pub_key_path : local.default_ssh_pub_key
+}

--- a/external/sketch/digitalocean/middle.tf
+++ b/external/sketch/digitalocean/middle.tf
@@ -1,0 +1,9 @@
+resource "digitalocean_droplet" "middle" {
+  name           = "middle${format("%02g", count.index + 1)}-${var.engagement_name}"
+  region          = var.middle_region
+  count           = var.middle_count
+  size            = var.middle_size
+  image           = var.docean_image
+  tags            = [var.engagement_name]
+  ssh_keys = [digitalocean_ssh_key.key.id]
+}

--- a/external/sketch/digitalocean/output.tf
+++ b/external/sketch/digitalocean/output.tf
@@ -1,0 +1,41 @@
+resource "local_file" "ssh_stanza" {
+  depends_on = [digitalocean_droplet.middle, digitalocean_droplet.edge]
+  filename = pathexpand("${var.ssh_config_path}/${var.engagement_name}-sketch")
+  file_permission = "0600"
+  content = templatefile("templates/ssh-stanza.tftpl", {
+    engagement_name = var.engagement_name,
+    ssh_private_key = local.ssh_priv_key_path
+    middles = digitalocean_droplet.middle.*,
+    edges = digitalocean_droplet.edge.*
+  })
+}
+
+resource "local_file" "ansible_inventory" {
+  depends_on = [digitalocean_droplet.middle, digitalocean_droplet.edge]
+  filename = "inventory.ini"
+  file_permission = "0600"
+  content = templatefile("templates/inventory.tftpl", {
+    middles = digitalocean_droplet.middle.*,
+    edges = digitalocean_droplet.edge.*,
+    ssh_priv_key_path = local.ssh_priv_key_path,
+    engagement_name = var.engagement_name
+  })
+}
+
+output "public-key" {
+  value = "${local.ssh_pub_key_path}"
+}
+
+output "run-ansible" {
+  depends_on = [local_file.ansible_inventory]
+  value = "Run ansible to configure hosts with:\n\tansible-playbook ../ansible/sketch-playbook.yml -i inventory.ini -e \"ssh_pub_key=${local.ssh_pub_key_path}\" -e \"ssh_config_path=${local.abs_ssh_config_path}\""
+}
+
+output "middle_public_ips" {
+  value = [for ip in digitalocean_droplet.middle: ip.ipv4_address]
+}
+
+output "good-bye" {
+  depends_on = [local_file.ansible_inventory]
+  value = "Have a nice day!"
+}

--- a/external/sketch/digitalocean/providers.tf
+++ b/external/sketch/digitalocean/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  token = var.do_pat
+}
+
+resource "digitalocean_ssh_key" "key" {
+  name = "do-key"
+  public_key = chomp(file(local.ssh_pub_key_path))
+}
+
+provider "local" {}

--- a/external/sketch/digitalocean/templates/inventory.tftpl
+++ b/external/sketch/digitalocean/templates/inventory.tftpl
@@ -1,0 +1,16 @@
+[all:vars]
+infra_user=ubuntu
+ansible_connection=ssh
+ansible_ssh_user=root
+ansible_ssh_host_key_checking=no
+ansible_ssh_common_args=-o UserKnownHostsFile=/dev/null -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${ssh_priv_key_path} -W %h:%p {{ infra_user }}@homebase-${engagement_name}'
+
+[middle]
+%{ for middle in middles ~}
+${middle.name}
+%{ endfor ~}
+
+[edge]
+%{ for edge in edges ~}
+${edge.name}
+%{ endfor ~}

--- a/external/sketch/digitalocean/templates/ssh-stanza.tftpl
+++ b/external/sketch/digitalocean/templates/ssh-stanza.tftpl
@@ -1,0 +1,15 @@
+%{ for middle in middles ~}
+Host ${middle.name}
+    User root
+    IdentityFile ${ssh_private_key}
+    Hostname ${middle.ipv4_address}
+    ProxyJump proxy01-${engagement_name}
+
+%{ for edge in edges ~}
+Host ${edge.name}
+    User root
+    IdentityFile ${ssh_private_key}
+    Hostname ${edge.ipv4_address}
+    ProxyJump ${middle.name}
+%{ endfor ~}
+%{ endfor ~}

--- a/external/sketch/digitalocean/variables.tf
+++ b/external/sketch/digitalocean/variables.tf
@@ -1,0 +1,49 @@
+variable "middle_region" {}
+variable "edge_regions" {}
+variable "docean_image" {}
+variable "do_pat" {}
+variable "engagement_name" {}
+
+variable "allowed_tcp_ports" {
+  description = "List of TCP ports to allow access to. This will be used to create the firewall rules."
+  default = ["22", "80", "443", "2222"]
+}
+
+variable "ssh_pub_key_path" {
+  description = "Path to the public key to be used for SSH access to the Droplets."
+  default = ""
+}
+
+variable "ssh_priv_key_path" {
+  description = "Path to the private key to be used for SSH access to the Droplets."
+  default = ""
+}
+
+variable "ssh_config_path" {
+  description = "Path to the SSH config directory. This is where the SSH config file will be written."
+  default = "~/.ssh"
+}
+
+# See https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/sizes
+# for determining sizes
+variable "edge_size" {
+  description = "Digital Ocean size to use for the edge nodes. Other options can be found at: https://slugs.do-api.dev/"
+  default = "s-1vcpu-1gb"
+}
+
+# See https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/sizes
+# for determining types
+variable "middle_size" {
+  description = "Digital Ocean size to use for the middle nodes. Other options can be found at: https://slugs.do-api.dev/"
+  default = "s-1vcpu-1gb"
+}
+
+variable "middle_count" {
+  description = "How many middle nodes to create."
+  default = 1
+}
+
+variable "edge_count_per_region" {
+  description = "How many edge nodes to create per region."
+  default = 1
+}

--- a/external/sketch/digitalocean/variables.tfvars.example
+++ b/external/sketch/digitalocean/variables.tfvars.example
@@ -1,0 +1,20 @@
+# Your Digital Ocean Personal Accecss Token
+do_pat = ""
+
+# Which Digital Ocean region should these be built in
+middle_region = ""
+edge_regions   = [""]
+
+# Host image you would like to use
+docean_image = ""
+
+# Shortname for the engagement, will be used to identify resources in Digital Ocean and hostnames
+engagement_name = ""
+
+# Path to place your ssh configuration for this infrastructure
+ssh_config_path = ""
+
+# Change me if you are using different keys than those that are generated with homebase instantiation.
+# Give the path to the private
+# ssh_priv_key_path =
+# ssh_pub_key_path =


### PR DESCRIPTION
This will allow operators to branch out and utilize Digital Ocean as a sketch provider instead of solely relying on Linode which was our only and default up until now.

Resolves #72 

## Changelog

**Updated**
* Added instructions for Digital Ocean to `external/sketch/README.md`

** Added**
* Provider `external/sketch/digitalocean`
* `external/sketch/digitalocean/edge.tf`
* `external/sketch/digitalocean/firewall.tf`
* `external/sketch/digitalocean/main.tf`
* `external/sketch/digitalocean/middle.tf`
* `external/sketch/digitalocean/output.tf`
* `external/sketch/digitalocean/password.tf`
* `external/sketch/digitalocean/providers.tf`
* `external/sketch/digitalocean/templates`
* `external/sketch/digitalocean/templates/inventory.tftpl`
* `external/sketch/digitalocean/templates/ssh-stanza.tftpl`
* `external/sketch/digitalocean/variables.tf`
* `external/sketch/digitalocean/variables.tfvars.example`
* `external/sketch/digitalocean/README.md`

