### PR TITLE
Automate Let's Encrypt SSL Certificate Renewal

### DIFF
--- a/ansible/playbooks/renew_certificates.yml
+++ b/ansible/playbooks/renew_certificates.yml
@@ -1,0 +1,16 @@
+- name: Deploy and schedule certificate renewal script
+  hosts: proxies
+  become: yes
+  tasks:
+    - name: Copy renew_certificates.sh to the target machine
+      copy:
+        src: roles/openresty/files/renew_certificates.sh
+        dest: /usr/local/bin/renew_certificates.sh
+        mode: '0755'
+
+    - name: Create cron job for certificate renewal
+      cron:
+        name: "Renew Let's Encrypt certificates"
+        minute: "0"
+        hour: "0"
+        job: "/usr/local/bin/renew_certificates.sh >> /var/log/renew_certificates.log 2>&1"

--- a/ansible/roles/openresty/files/nginx.conf
+++ b/ansible/roles/openresty/files/nginx.conf
@@ -17,6 +17,10 @@ http {
     tcp_nopush on;
     tcp_nodelay on;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    } 
+
 
     ##
     # SSL Settings

--- a/ansible/roles/openresty/files/renew_certificates.sh
+++ b/ansible/roles/openresty/files/renew_certificates.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Define your domains
+DOMAINS=("your_domain1.com" "your_domain2.com")
+
+# Define the webroot path for the ACME challenge
+WEBROOT_PATH="/var/www/certbot"
+
+# Ensure the webroot path exists
+mkdir -p $WEBROOT_PATH
+
+# Loop through each domain and renew the certificate
+for DOMAIN in "${DOMAINS[@]}"; do
+    sudo certbot certonly --manual --preferred-challenges=http --manual-auth-hook "echo 'auth hook'" --manual-cleanup-hook "echo 'cleanup hook'" --webroot -w $WEBROOT_PATH -d $DOMAIN --force-renew
+done
+
+# Reload Nginx to apply the new certificates
+sudo systemctl reload nginx

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -15,4 +15,5 @@
 - import_playbook: users/users.yml
 
 - import_playbook: playbooks/reboot.yml
+- import_playbook: playbooks/renew_certificates.yml
 


### PR DESCRIPTION
# Summary

This pull request automates the renewal of Let's Encrypt SSL certificates, addressing the manual and error-prone process. Key changes include:

1. **Nginx Configuration Update**:
   - Added a location block to allow the ACME challenge to pass through.

2. **Certificate Renewal Script**:
   - Created `renew_certificates.sh` to handle the renewal process using `certbot`.
   - Placed the script in `ansible/roles/openresty/files/`.
 
3. **Ansible Playbook Update**:
   - Added `renew_certificates.yml` to deploy the script and set up a cron job.
   - Updated `site.yml` to include the new playbook.

## Changes

- **Nginx Configuration**:
  - Updated to allow the ACME challenge to pass through.

- **Certificate Renewal Script**:
  - Created a script to automate the renewal process and reload Nginx.

- **Ansible Playbook**:
  - Added a playbook to deploy the script and set up a cron job.
  - Updated the main site playbook to include the new playbook.


## Notes
- Still in the process of trying to get my cloud provider accounts setup, hence I wasn't able to test it using this repository. 
- Ideally if necessary am willing to make a smaller version on my own repo with only access to AWS to verify it.