### PR TITLE
Add datetime stamp to homebase tty shells

### DIFF
--- a/ansible/roles/homebase/tasks/main.yml
+++ b/ansible/roles/homebase/tasks/main.yml
@@ -83,3 +83,16 @@
   register: result
   failed_when: result.rc >= 2
 
+- name: Add system-wide UTC PS1 to /etc/bash.bashrc
+  blockinfile:
+    path: /etc/bash.bashrc
+    block: |
+      # System-wide UTC PS1 for all interactive shells
+      if [[ $- == *i* ]] && ! [ -n "${SUDO_USER}" -a -n "${SUDO_PS1}" ]; then
+          PROMPT_COMMAND='PS1="\[\e[36m\]$(TZ=UTC date "+%Y-%m-%d %H:%M:%S UTC")\[\e[0m\] ~ \
+      \[\e[32m\]\u@\h\[\e[0m\]:\
+      \[\e[31m\]\w\[\e[0m\]\$ "'
+      fi
+    marker: "# {mark} ANSIBLE UTC PS1"
+    create: yes
+    backup: yes


### PR DESCRIPTION
Resolves  #96 

```
Welcome to Ubuntu 22.04.5 LTS (GNU/Linux 6.8.0-1041-oracle x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

 System information as of Wed Jan  7 20:16:09 UTC 2026

  System load:  0.24               Processes:             153
  Usage of /:   1.5% of 496.03GB   Users logged in:       0
  Memory usage: 9%                 IPv4 address for ens3: 192.168.0.10
  Swap usage:   0%


Expanded Security Maintenance for Applications is not enabled.

2 updates can be applied immediately.
To see these additional updates run: apt list --upgradable

10 additional security updates can be applied with ESM Apps.
Learn more about enabling ESM Apps service at https://ubuntu.com/esm


Last login: Fri Dec 19 18:16:22 2025 from X.X.X.X
2026-01-07 20:16:11 UTC ~ aluvshis@homebase-aluvshis-dev:~$ cd /dropbox/
2026-01-07 20:16:16 UTC ~ aluvshis@homebase-aluvshis-dev:/dropbox$ ls
```