### PR TITLE
Engagement directory

### DIFF
--- a/ansible/roles/homebase/tasks/main.yml
+++ b/ansible/roles/homebase/tasks/main.yml
@@ -96,3 +96,11 @@
     marker: "# {mark} ANSIBLE UTC PS1"
     create: yes
     backup: yes
+
+- name: Create /engagement directory
+  ansible.builtin.file:
+    path: /engagement
+    state: directory
+    owner: root
+    group: redteam
+    mode: "2775"


### PR DESCRIPTION
Historically, we've been using `/dropbox` to hold things like KeePass DBs, keys, loot, etc. Should sketch get popped and in turnproxies, threat actors can acquire anything that is in `/dropbox. `

This `/engagement` directory should be use to hold engagement data like keepass dbs, loot, passwords, etc and it's only accessible on homebase.