### PR TITLE
Certificate leak fix using dockerized websites to request individual SSL certificates

### DIFF
--- a/ansible/roles/openresty-v2/README.md
+++ b/ansible/roles/openresty-v2/README.md
@@ -1,0 +1,47 @@
+Role Name
+=========
+
+Deploying of multiple websites using docker containers to handle certificate leaks. Will automatically create the website, request the SSL certificate, enable HTTPS and redirects from HTTP to HTTPS.
+
+Requirements
+------------
+
+Requires having homebase and sketch setup properly. You will need the middle IPs and Proxy IPs.
+Requires the docker role.
+Requires grabbing latest IP blocks for ProofPoint (aws.conf, leaseweb.conf, m247.conf)
+
+Additions
+---------
+
+This should be ran alongside backflips-v2 which are also dockerized SSH backflips to avoid SSH keyfingerprinting.
+
+Example Playbook
+----------------
+
+Create a new playbook file and insert below into it while adding as many proxies as setup
+
+```
+---
+- hosts: proxy01-ENGAGEMENT-PROD
+  become: yes
+  roles:
+    - docker
+    - openresty-v2
+  vars:
+    domain_names:
+      - example.com
+      - example2.com
+    middle_ip: "MIDDLE1_IP"
+
+- hosts: proxy02-ENGAGEMENT-PROD
+  become: yes
+  roles:
+    - docker
+    - openresty-v2
+  vars:
+    domain_names:
+      - example3.com
+    middle_ip: "MIDDLE2_IP"
+```
+
+Then call it using `ansible-playbook -i site.yml THIS_PLAYBOOK.yml`

--- a/ansible/roles/openresty-v2/defaults/main.yml
+++ b/ansible/roles/openresty-v2/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for openresty-v2

--- a/ansible/roles/openresty-v2/files/aws.conf
+++ b/ansible/roles/openresty-v2/files/aws.conf
@@ -1,0 +1,10 @@
+# Built by Sephiroth on 2024-09-05 21:17:23.618415 (UTC)
+# (aws) syncToken: 1725556989
+# (aws) createDate: 2024-09-05-17-23-09
+
+geo $proxy_protocol_addr $block_aws {
+    default 0;
+    
+}
+
+# Built by Sephiroth on 2024-09-05 21:17:23.618415 (UTC)

--- a/ansible/roles/openresty-v2/files/index.html
+++ b/ansible/roles/openresty-v2/files/index.html
@@ -1,0 +1,1 @@
+hello world

--- a/ansible/roles/openresty-v2/files/leaseweb.conf
+++ b/ansible/roles/openresty-v2/files/leaseweb.conf
@@ -1,0 +1,10 @@
+# Built by Sephiroth on 2024-09-05 21:16:42.213378 (UTC)
+# (asn) ASN Data collected from api.hackertarget.com
+
+geo $proxy_protocol_addr $block_lw {
+    default 0;
+   
+    
+}
+
+# Built by Sephiroth on 2024-09-05 21:16:42.213378 (UTC)

--- a/ansible/roles/openresty-v2/files/m247.conf
+++ b/ansible/roles/openresty-v2/files/m247.conf
@@ -1,0 +1,10 @@
+# Built by Sephiroth on 2024-09-05 21:15:25.179899 (UTC)
+# (asn) ASN Data collected from api.hackertarget.com
+
+geo $proxy_protocol_addr $block_m247 {
+    default 0;
+
+    
+}
+
+# Built by Sephiroth on 2024-09-05 21:15:25.179899 (UTC)

--- a/ansible/roles/openresty-v2/files/nginx.conf
+++ b/ansible/roles/openresty-v2/files/nginx.conf
@@ -1,0 +1,42 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+
+user www-data;
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    map_hash_bucket_size 256;	
+    include /etc/openresty/m247.conf;
+    include /etc/openresty/leaseweb.conf;
+    include /etc/openresty/aws.conf;
+
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile           on;
+    keepalive_timeout  65;
+
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    # Allow for larger sliver "downloads" from victim
+    client_max_body_size 1024M;
+
+    ##
+    # SSL Settings
+    ##
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+    ssl_prefer_server_ciphers on;
+
+    include /etc/nginx/sites-enabled/*;
+
+    log_format proxy '$proxy_protocol_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_host"';
+}
+
+stream {
+   include /etc/nginx/streams/*;
+}

--- a/ansible/roles/openresty-v2/handlers/main.yml
+++ b/ansible/roles/openresty-v2/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for openresty-v2

--- a/ansible/roles/openresty-v2/meta/main.yml
+++ b/ansible/roles/openresty-v2/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/ansible/roles/openresty-v2/provision.sh
+++ b/ansible/roles/openresty-v2/provision.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Provisioning script if needed or wanted. Not necessary to use just something to automate a few steps.
+
+echo "Provisioning OCI resources..."
+cd /path/to/oci/terraform
+terraform init
+terraform apply -var-file=variables.tfvars -auto-approve
+
+echo "Configuring OCI resources..."
+cd ../../ansible && ansible-playbook -i inventory.ini site.yml
+
+
+echo "Provisioning Sketch resources..."
+cd /path/to/do/terraform
+terraform init
+terraform apply -var-file=variables.tfvars -auto-approve
+
+echo "Configuring Sketch resources..."
+ansible-playbook ../ansible/sketch-playbook.yml -i inventory.ini -e "ssh_pub_key=/home/user/.ssh/user-dev.pub" -e "ssh_config_path=/home/user/.ssh/redteam-sshconfigs/configs/user-dev-sketch"
+
+# Step 3: Trigger additional OCI configuration
+echo "Running additional OCI configuration..."
+cd /path/to/playbook
+ansible-playbook -i inventory.ini openresty-proxy-pb.yml
+
+echo "Automation complete!"

--- a/ansible/roles/openresty-v2/tasks/main.yml
+++ b/ansible/roles/openresty-v2/tasks/main.yml
@@ -1,0 +1,146 @@
+---
+# tasks file for openresty-v2
+- name: Create general web directory
+  file:
+    path: /opt/web
+    state: directory
+    owner: root
+    mode: 0755
+    recurse: yes
+
+- name: Create reverse-proxy site-enabled directory
+  file:
+    path: /opt/web/conf
+    state: directory
+    owner: root
+    mode: 0755
+    recurse: yes
+
+- name: Create reverse proxy streams directory
+  file:
+    path: /opt/web/streams
+    state: directory
+    owner: root
+    mode: 0755
+    recurse: yes 
+
+- name: Create sites-enabled directories for domains
+  file:
+    path: "/opt/web/{{ item }}/conf"
+    state: directory
+    mode: 0755
+  loop: "{{ domain_names }}"
+
+- name: Create HTML directories for domains
+  file:
+    path: "/opt/web/{{ item }}/html"
+    state: directory
+    mode: 0755
+  loop: "{{ domain_names }}"
+
+- name: Copy openresty config
+  copy:
+    src: files/nginx.conf
+    dest: /opt/web/nginx.conf
+    owner: root
+    mode: 0644
+
+- name: Copy aws ip-block conf
+  copy:
+    src: files/aws.conf
+    dest: /opt/web/aws.conf
+    owner: root
+    mode: 0644
+
+- name: Copy m247 ip-block conf
+  copy:
+    src: files/m247.conf
+    dest: /opt/web/m247.conf
+    owner: root
+    mode: 0644
+
+- name: Copy leaseweb ip-block conf
+  copy:
+    src: files/leaseweb.conf
+    dest: /opt/web/leaseweb.conf
+    owner: root
+    mode: 0644
+
+- name: Copy basic web page into domains HTML directories
+  copy:
+    src: files/index.html
+    dest: "/opt/web/{{ item }}/html"
+    owner: root
+    mode: 0644
+  loop: "{{ domain_names }}"
+
+- name: Configure reverse-proxy websites for certbot
+  template:
+    src: templates/rev-proxy-domain-http.conf.j2
+    dest: "/opt/web/conf/{{ item }}"
+    mode: 0644
+    owner: root
+  loop: "{{ domain_names }}"
+
+- name: Configure proxy streams
+  template:
+    src: templates/streams.conf.j2
+    dest: /opt/web/streams/streams.conf
+    mode: 0644
+    owner: root
+
+- name: Create web_webnet docker network
+  docker_network:
+    name: web_webnet
+    driver: bridge
+    state: present
+
+- name: Configure containers
+  template:
+    src: templates/docker-compose.yml.j2
+    dest: /opt/web/docker-compose.yml
+    mode: 0644
+    owner: root
+
+- name: Configure http domains for certbot
+  template:
+    src: templates/website-http.conf.j2
+    dest: "/opt/web/{{ item }}/conf/{{ item }}"
+    mode: 0644
+    owner: root
+  loop: "{{ domain_names }}"
+
+- name: Start containers for certbot
+  command: docker compose -f /opt/web/docker-compose.yml up -d
+  args:
+    chdir: /opt/web
+    
+- name: Run certbot for domains
+  command: "docker run --rm -v 'web_certbot-etc:/etc/letsencrypt' -v 'web_certbot-www:/var/www/certbot' certbot/certbot certonly --webroot -w /var/www/certbot -m adam.luvshis@oracle.com --agree-tos -d {{ item }} -v --non-interactive"
+  loop: "{{ domain_names }}"
+
+- name: Stop containers for HTTPS
+  command: docker compose -f /opt/web/docker-compose.yml down
+  args:
+    chdir: /opt/web
+
+- name: Overwrite config for HTTPS
+  template:
+    src: templates/website-https.conf.j2
+    dest: "/opt/web/{{ item }}/conf/{{ item }}"
+    mode: 0644
+    owner: root
+  loop: "{{ domain_names }}"
+
+- name: Overwrite reverse-proxy websites for HTTPs
+  template:
+    src: templates/rev-proxy-domain-https.conf.j2
+    dest: "/opt/web/conf/{{ item }}"
+    mode: 0644
+    owner: root
+  loop: "{{ domain_names }}"
+
+- name: Start containers again
+  command: docker compose -f /opt/web/docker-compose.yml up -d
+  args:
+    chdir: /opt/web

--- a/ansible/roles/openresty-v2/templates/docker-compose.yml.j2
+++ b/ansible/roles/openresty-v2/templates/docker-compose.yml.j2
@@ -1,0 +1,80 @@
+services:
+  reverse-proxy:
+    image: openresty/openresty:latest
+    container_name: proxy
+    hostname: proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /opt/web/nginx.conf:/etc/openresty/nginx.conf
+      - /opt/web/nginx.conf:/etc/nginx/conf.d/default.conf
+      - /opt/web/m247.conf:/etc/openresty/m247.conf
+      - /opt/web/aws.conf:/etc/openresty/aws.conf
+      - /opt/web/leaseweb.conf:/etc/openresty/leaseweb.conf
+      - /opt/web/conf:/etc/nginx/sites-enabled
+      - /opt/web/streams:/etc/nginx/streams
+      - certbot-etc:/etc/letsencrypt
+      - certbot-www:/var/www/certbot
+    depends_on:
+{% for domain in domain_names %}{% set stripped_domain = domain | regex_replace('\\.[^.]+$', '') %}
+      - {{ stripped_domain }}
+{% endfor %}
+    links:
+{% for domain in domain_names %}{% set stripped_domain = domain | regex_replace('\\.[^.]+$', '') %}
+      - {{ stripped_domain }}
+{% endfor %}
+    networks:
+      - web_webnet
+    restart: unless-stopped
+
+  certbot:
+    image: certbot/certbot:latest
+    container_name: certbot
+    hostname: certbot
+    volumes:
+      - certbot-etc:/etc/letsencrypt
+      - certbot-www:/var/www/certbot
+    entrypoint: >
+      /bin/sh -c "
+        trap exit TERM;
+        while :; do
+          certbot renew --webroot -w /var/www/certbot --quiet;
+          sleep 12h & wait $${!};
+        done;
+      "
+    depends_on:
+      - reverse-proxy
+    networks:
+      - web_webnet
+    restart: unless-stopped
+
+  {% for domain in domain_names %}{% set stripped_domain = domain | regex_replace('\\.[^.]+$', '') %}{{ stripped_domain }}:
+    image: openresty/openresty:latest
+    hostname: {{ stripped_domain }}
+    container_name: {{ stripped_domain }}
+    expose:
+      - "8081"
+    volumes:
+      - /opt/web/nginx.conf:/etc/nginx/conf.d/default.conf
+      - /opt/web/nginx.conf:/etc/openresty/nginx.conf
+      - /opt/web/m247.conf:/etc/openresty/m247.conf
+      - /opt/web/aws.conf:/etc/openresty/aws.conf
+      - /opt/web/leaseweb.conf:/etc/openresty/leaseweb.conf
+      - /opt/web/{{ domain }}/conf:/etc/nginx/sites-enabled
+      - /opt/web/{{ domain }}/html:/var/www/html/{{ domain }}
+      - certbot-etc:/etc/letsencrypt
+      - certbot-www:/var/www/certbot
+    networks:
+      - web_webnet
+    restart: unless-stopped
+
+  {% endfor %}
+
+volumes:
+  certbot-etc:
+  certbot-www:
+
+networks:
+  web_webnet:
+    driver: bridge

--- a/ansible/roles/openresty-v2/templates/rev-proxy-domain-http.conf.j2
+++ b/ansible/roles/openresty-v2/templates/rev-proxy-domain-http.conf.j2
@@ -1,0 +1,13 @@
+{% set domain = item %}
+{% set stripped_domain = domain.split('.')[0] %}
+server {
+    listen 80 proxy_protocol;
+    server_name $host;
+
+    location ~ /.well-known {
+        root /var/www/certbot;
+        allow all;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+   }
+   real_ip_header proxy_protocol; 
+}

--- a/ansible/roles/openresty-v2/templates/rev-proxy-domain-https.conf.j2
+++ b/ansible/roles/openresty-v2/templates/rev-proxy-domain-https.conf.j2
@@ -1,0 +1,7 @@
+{% set domain = item %}
+{% set stripped_domain = domain.split('.')[0] %}
+server {
+    listen 80 proxy_protocol;
+    server_name $host;
+    return 301 https://$host$request_uri;
+}

--- a/ansible/roles/openresty-v2/templates/streams.conf.j2
+++ b/ansible/roles/openresty-v2/templates/streams.conf.j2
@@ -1,0 +1,14 @@
+# Mapping HTTP Backends
+map $ssl_preread_server_name $httpBackend {
+{% for domain in domain_names %}
+{% set stripped_domain = domain | regex_replace('^.*?([^.]+\.[^.]+)$', '\\1') %}
+    {{ domain }}  {{ stripped_domain }}:8081;
+{% endfor %}
+}
+
+server {
+    listen 443 proxy_protocol;
+    resolver 127.0.0.11;
+    ssl_preread on;
+    proxy_pass $httpBackend;
+}q

--- a/ansible/roles/openresty-v2/templates/website-http.conf.j2
+++ b/ansible/roles/openresty-v2/templates/website-http.conf.j2
@@ -1,0 +1,14 @@
+{% set domain = item %}
+server {
+        listen 8081;
+        root /var/www/html/{{ domain }};
+        index index.html;
+        server_name {{ domain }};
+  
+        location ~ /.well-known {
+                root /var/www/certbot;
+                allow all;
+                proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        }
+        real_ip_header proxy_protocol;
+}

--- a/ansible/roles/openresty-v2/templates/website-https.conf.j2
+++ b/ansible/roles/openresty-v2/templates/website-https.conf.j2
@@ -1,0 +1,51 @@
+{% set domain = item %}
+
+upstream {{ groups['homebase'][0] }}.infra.redteam {
+    server 192.168.0.10:443;
+}
+
+map $http_user_agent $is_my_agent {
+	default 0;
+	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" 1;
+}
+
+map $http_authorization $is_valid_token {
+	default 0;
+	"Bearer aGVsbG9zMQo=" 1;
+}
+
+server {
+    listen 8081 ssl;        
+      
+    root /var/www/html/{{ domain }};
+    index index.html;
+    server_name {{ domain }};
+  
+    real_ip_header proxy_protocol;
+      
+    ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
+
+    if ($block_aws)   {
+        return 308 https://google.com/;
+    }
+    if ($block_lw) {
+        return 308 https://google.com/;
+    }
+    if ($block_m247) {
+        return 308 https://google.com/;
+    }
+
+    location ~ /code/bugs {
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        satisfy all;
+        if ($is_valid_token = 0) {
+            return 403;	   
+        }
+        if ($is_my_agent = 0) {
+            return 403;
+        }
+
+        proxy_pass https://{{ groups['homebase'][0] }}.infra.redteam;
+    }
+}

--- a/ansible/roles/openresty-v2/tests/inventory
+++ b/ansible/roles/openresty-v2/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible/roles/openresty-v2/tests/test.yml
+++ b/ansible/roles/openresty-v2/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - openresty-v2

--- a/ansible/roles/openresty-v2/vars/main.yml
+++ b/ansible/roles/openresty-v2/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for openresty-v2


### PR DESCRIPTION
Adds the openresty-v2 role: each domain gets its own reverse-proxy container and requests its own cert via containerized certbot, instead of sharing a single certificate across domains.

Resolves #71 