### PR TITLE
Removed stray character; fixed subdomains as a domain

### DIFF
--- a/ansible/roles/openresty-v2/templates/rev-proxy-domain-http.conf.j2
+++ b/ansible/roles/openresty-v2/templates/rev-proxy-domain-http.conf.j2
@@ -1,5 +1,4 @@
 {% set domain = item %}
-{% set stripped_domain = domain.split('.')[0] %}
 server {
     listen 80 proxy_protocol;
     server_name $host;

--- a/ansible/roles/openresty-v2/templates/rev-proxy-domain-https.conf.j2
+++ b/ansible/roles/openresty-v2/templates/rev-proxy-domain-https.conf.j2
@@ -1,5 +1,4 @@
 {% set domain = item %}
-{% set stripped_domain = domain.split('.')[0] %}
 server {
     listen 80 proxy_protocol;
     server_name $host;

--- a/ansible/roles/openresty-v2/templates/streams.conf.j2
+++ b/ansible/roles/openresty-v2/templates/streams.conf.j2
@@ -1,7 +1,7 @@
 # Mapping HTTP Backends
 map $ssl_preread_server_name $httpBackend {
 {% for domain in domain_names %}
-{% set stripped_domain = domain | regex_replace('^.*?([^.]+\.[^.]+)$', '\\1') %}
+{% set stripped_domain = domain | regex_replace('\\.[^.]+$', '') %}
     {{ domain }}  {{ stripped_domain }}:8081;
 {% endfor %}
 }
@@ -11,4 +11,4 @@ server {
     resolver 127.0.0.11;
     ssl_preread on;
     proxy_pass $httpBackend;
-}q
+}


### PR DESCRIPTION
There was a stray 'q' in one of the confs which would cause this to fail.

Fixed the issue so if a sub-domain is supplied the containers are appropriately named.